### PR TITLE
DPDK 2.0.0 virtio update

### DIFF
--- a/configure
+++ b/configure
@@ -705,6 +705,8 @@ xen_dir
 INCLUDE_KSYMS
 LINUXMODULE_FIXINCLUDES
 USE_DPDK
+RTE_VER_MINOR
+RTE_VER_MAJOR
 PTHREAD_LIBS
 HAVE_BATCH
 AR_CREATEFLAGS
@@ -6375,7 +6377,6 @@ fi
 
 PTHREAD_LIBS=""
 
-
 if test "x$enable_user_multithread" = xyes; then
     SAVE_LIBS="$LIBS"
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing pthread_create" >&5
@@ -6568,6 +6569,11 @@ Define \$RTE_SDK and \$RTE_TARGET as per Intel DPDK documentation.
 
 =========================================" "$LINENO" 5
     fi
+    rte_ver_major=`cat $RTE_SDK/$RTE_TARGET/include/rte_version.h | grep "#define RTE_VER_MAJOR" | head -n 1 | awk '{print $3}'`
+    rte_ver_minor=`cat $RTE_SDK/$RTE_TARGET/include/rte_version.h | grep "#define RTE_VER_MINOR" | head -n 1 | awk '{print $3}'`
+    RTE_VER_MAJOR=$rte_ver_major
+    RTE_VER_MINOR=$rte_ver_minor
+
     $as_echo "#define HAVE_DPDK 1" >>confdefs.h
 
     USE_DPDK=yes

--- a/configure.in
+++ b/configure.in
@@ -193,6 +193,10 @@ Define \$RTE_SDK and \$RTE_TARGET as per Intel DPDK documentation.
 
 =========================================])
     fi
+    rte_ver_major=`cat $RTE_SDK/$RTE_TARGET/include/rte_version.h | grep "#define RTE_VER_MAJOR" | head -n 1 | awk '{print $3}'`
+    rte_ver_minor=`cat $RTE_SDK/$RTE_TARGET/include/rte_version.h | grep "#define RTE_VER_MINOR" | head -n 1 | awk '{print $3}'`
+    AC_SUBST(RTE_VER_MAJOR, $rte_ver_major)
+    AC_SUBST(RTE_VER_MINOR, $rte_ver_minor)
     AC_DEFINE([HAVE_DPDK])
     AC_SUBST(USE_DPDK, yes)
 fi

--- a/userlevel/Makefile.in
+++ b/userlevel/Makefile.in
@@ -101,6 +101,8 @@ CCLD = $(CC)
 LINK = $(CCLD) $(CFLAGS) $(LDFLAGS) -o $@
 
 USE_DPDK = @USE_DPDK@
+RTE_VER_MAJOR = @RTE_VER_MAJOR@
+RTE_VER_MINOR = @RTE_VER_MINOR@
 ifeq ($(USE_DPDK),yes)
 include dpdk.mk
 EXTRA_DRIVER_OBJS := dpdkdevice.o $(EXTRA_DRIVER_OBJS)

--- a/userlevel/dpdk.mk
+++ b/userlevel/dpdk.mk
@@ -145,7 +145,11 @@ LIBS += -lrte_pmd_vmxnet3_uio
 endif
 
 ifeq ($(CONFIG_RTE_LIBRTE_VIRTIO_PMD),y)
-LIBS += -lrte_pmd_virtio_uio
+ifeq ($(shell [ $(RTE_VER_MAJOR) -ge 2 ] && echo true),true)
+  LIBS += -lrte_pmd_virtio
+else
+  LIBS += -lrte_pmd_virtio_uio
+endif
 endif
 
 ifeq ($(CONFIG_RTE_LIBRTE_I40E_PMD),y)


### PR DESCRIPTION
DPDK 2.0.0 renamed the rte_pmd_virtio_uio library to rte_pmd_virtio (commit http://dpdk.org/browse/dpdk/commit/?id=b652e6cdff6f144071dd307b2e366e166b8c8b70).  To keep supporting 1.7, I wrote a few lines to pull version number from RTE_TARGET/include/rte_version.h, and include it in substitutions in the Makefiles, so that version specific future updates can be handled.
